### PR TITLE
Add navbar link to Wakatime home

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -22,3 +22,11 @@ status-website:
   logoHref: https://wakatime.com
   introTitle: WakaTime Status
   introMessage: This page shows **real-time** status of the WakaTime website and API.
+  navbar:
+    - title: Status
+      href: /
+    - title: WakaTime Home
+      href: https://wakatime.com
+    - title: GitHub
+      href: https://github.com/$OWNER/$REPO
+


### PR DESCRIPTION
Upptime now supports custom links in the navbar. By default, the navbar will be empty. This PR changes the navbar to these links: "Status", "WakaTime Home" (for the website), and "GitHub" (for this repo).

Docs for navbar: https://upptime.js.org/docs/configuration#navbar-links
